### PR TITLE
Adding the tgdb cog to the master branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 Random cogs to keep the tg admin team happy, don't look or you will lose sanity
 
 ### Credits:
-- [Crossedfall](https://github.com/crossedfall/crossed-cogs) for his cogs that made me setup a redbot instance
+- [Crossedfall](https://github.com/crossedfall/crossed-cogs) for his cogs that made me setup a redbot instance, and for the getnotes work I built upon for the tgdb command set
 - The [/TG/ community](https://github.com/tgstation) for their efforts on SS13 
 - The [Cog-Creators](https://github.com/Cog-Creators) staff for their work on redbot

--- a/tgcommon/setup.py
+++ b/tgcommon/setup.py
@@ -1,0 +1,20 @@
+
+from setuptools import setup
+
+setuptools.setup(
+    name="tgcommon-oranges",
+    version="0.0.3",
+    author="oranges",
+    author_email="email@oranges.net.nz",
+    description="Common code for the tg cogs",
+    long_description="Common code for the tg cogs connecting to a tg ss13 database",
+    long_description_content_type="text", #text/markdown later
+    url="https://github.com/optimumtact/orangescogs",
+    packages=['tgcommon'],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)

--- a/tgcommon/setup.py
+++ b/tgcommon/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setuptools.setup(
     name="tgcommon-oranges",
-    version="0.0.3",
+    version="0.0.5",
     author="oranges",
     author_email="email@oranges.net.nz",
     description="Common code for the tg cogs",

--- a/tgcommon/tgcommon/__init__.py
+++ b/tgcommon/tgcommon/__init__.py
@@ -1,0 +1,1 @@
+# Common classes/uses for tgstation code

--- a/tgcommon/tgcommon/errors.py
+++ b/tgcommon/tgcommon/errors.py
@@ -1,0 +1,12 @@
+#Discord Imports
+import discord
+
+#Redbot Imports
+from redbot.core import commands, checks, Config
+
+#Subtype the commands checkfailure
+class TGRecoverableError(commands.CheckFailure):
+    pass
+
+class TGUnrecoverableError(commands.CheckFailure):
+    pass

--- a/tgcommon/tgcommon/models.py
+++ b/tgcommon/tgcommon/models.py
@@ -1,0 +1,7 @@
+"""
+Models that map to database tables in tgstation database schema
+TODO: investigate SQL alchemy for this?
+"""
+from collections import namedtuple
+
+DiscordLink = namedtuple('DiscordLink', 'id, ckey, discord_id, timestamp, one_time_token')

--- a/tgcommon/tgcommon/models.py
+++ b/tgcommon/tgcommon/models.py
@@ -4,4 +4,17 @@ TODO: investigate SQL alchemy for this?
 """
 from collections import namedtuple
 
-DiscordLink = namedtuple('DiscordLink', 'id, ckey, discord_id, timestamp, one_time_token')
+BaseLink = namedtuple('DiscordLink', 'id, ckey, discord_id, timestamp, one_time_token, valid')
+
+class DiscordLink(BaseLink):
+
+    @classmethod
+    def from_db_record(cls, record):
+        #Unpack it
+        return cls(**record)
+    
+    @property
+    def validity(self):
+        if self.valid > 0:
+            return True
+        return False

--- a/tgcommon/tgcommon/util.py
+++ b/tgcommon/tgcommon/util.py
@@ -1,0 +1,4 @@
+import re
+
+def normalise_to_ckey(key):
+	return re.sub('[^A-Za-z0-9]+', '', key)

--- a/tgdb/__init__.py
+++ b/tgdb/__init__.py
@@ -1,0 +1,4 @@
+from .tgdb import TGDB
+
+def setup(bot):
+    bot.add_cog(TGDB(bot))

--- a/tgdb/info.json
+++ b/tgdb/info.json
@@ -1,0 +1,18 @@
+{
+    "author": ["oranges"],
+    "install_msg": "Thank you for installing tgdb.",
+    "name": "SS13 tgdb module",
+    "short": "Base module for helper cogs that interoperate with the tg database schema",
+    "requirements": [
+        "aiomysql>=0.0.20"
+    ],
+    "description": "Interoperability plugin for a discord bot, connects to any database using the latest tg schema",
+    "permissions" : ["Manage Messages", "Embed Links"],
+    "tags": [
+        "Space Station 13",
+        "Game",
+        "Administration",
+        "Utility",
+        "SS13"
+    ]
+}

--- a/tgdb/tgdb.py
+++ b/tgdb/tgdb.py
@@ -45,7 +45,6 @@ class TGDB(BaseCog):
         }
 
         self.config.register_guild(**default_guild)
-        self.loop = asyncio.get_event_loop()
         self.pool = None
 
     @commands.guild_only()
@@ -56,12 +55,20 @@ class TGDB(BaseCog):
         SS13 Configure the MySQL database connection settings
         """
         pass
-    
-    @tgdb_config.command()
+
+    @commands.guild_only()
+    @commands.group()
     @checks.is_owner()
+    async def tgdb(self,ctx): 
+        """
+        SS13 Configure the MySQL database connection settings
+        """
+        pass
+    
+    @tgdb.command()
     async def reconnect(self, ctx):
         """
-        Sets the MySQL host, defaults to localhost (127.0.0.1)
+        Recreate the pool (for when it dies)
         """
         db = await self.config.guild(ctx.guild).mysql_db()
         db_host = socket.gethostbyname(await self.config.guild(ctx.guild).mysql_host())
@@ -316,8 +323,8 @@ class TGDB(BaseCog):
             self.pool.close()
             await self.pool.wait_closed()
         
-        # Establish a connection with the database and pull the relevant data
-        self.pool = await aiomysql.create_pool(host=db_host,port=db_port,db=db,user=db_user,password=db_pass, connect_timeout=5)
+        # Establish a connection with the database and pull the relevant data, recycle them every 300 seconds
+        self.pool = await aiomysql.create_pool(host=db_host,port=db_port,db=db,user=db_user,password=db_pass, connect_timeout=5, pool_recycle=300)
 
     async def query_database(self, ctx, query: str, parameters: list):
         '''

--- a/tgdb/tgdb.py
+++ b/tgdb/tgdb.py
@@ -1,0 +1,332 @@
+#Standard Imports
+import asyncio
+import aiomysql
+import socket
+import ipaddress
+import re
+import logging
+from typing import Union
+from collections import namedtuple
+
+#Discord Imports
+import discord
+
+#Redbot Imports
+from redbot.core import commands, checks, Config
+from redbot.core.utils.chat_formatting import pagify, box, humanize_list, warning
+from redbot.core.utils.menus import menu, DEFAULT_CONTROLS
+
+#Util Imports
+from .util import key_to_ckey
+
+__version__ = "1.0.0"
+__author__ = "oranges"
+
+log = logging.getLogger("red.oranges_tgdb")
+
+BaseCog = getattr(commands, "Cog", object)
+
+DiscordLink = namedtuple('DiscordLink', 'id, ckey, discord_id, timestamp, one_time_token')
+
+class TGDB(BaseCog):
+    """
+    Connector that will integrate with any database using the latest tg schema, provides utility functionality
+    """
+    def __init__(self, bot):
+        self.bot = bot
+        self.config = Config.get_conf(self, identifier=672261474290237490, force_registration=True)
+        self.visible_config = ["mysql_host", "mysql_port", "mysql_user", "mysql_db", "mysql_prefix",
+        "min_living_minutes", "verified_role"]
+
+        default_guild = {
+            "mysql_host": "127.0.0.1",
+            "mysql_port": 3306,
+            "mysql_user": "ss13",
+            "mysql_password": "password",
+            "mysql_db": "database",
+            "mysql_prefix": "",
+            "min_living_minutes": 60,
+            "verified_role": None,
+        }
+
+        self.config.register_guild(**default_guild)
+        self.loop = asyncio.get_event_loop()
+    
+
+    @commands.guild_only()
+    @commands.group()
+    @checks.admin_or_permissions(administrator=True)
+    async def tgdb_config(self,ctx): 
+        """
+        SS13 Configure the MySQL database connection settings
+        """
+        pass
+    
+
+    @tgdb_config.command()
+    @checks.is_owner()
+    async def host(self, ctx, db_host: str):
+        """
+        Sets the MySQL host, defaults to localhost (127.0.0.1)
+        """
+        try:
+            await self.config.guild(ctx.guild).mysql_host.set(db_host)
+            await ctx.send(f"Database host set to: `{db_host}`")
+        except (ValueError, KeyError, AttributeError):
+            await ctx.send("There was an error setting the database's ip/hostname. Please check your entry and try again!")
+    
+
+    @tgdb_config.command()
+    @checks.is_owner()
+    async def port(self, ctx, db_port: int):
+        """
+        Sets the MySQL port, defaults to 3306
+        """
+        try:
+            if 1024 <= db_port <= 65535: # We don't want to allow reserved ports to be set
+                await self.config.guild(ctx.guild).mysql_port.set(db_port)
+                await ctx.send(f"Database port set to: `{db_port}`")
+            else:
+                await ctx.send(f"{db_port} is not a valid port!")
+        except (ValueError, KeyError, AttributeError):
+            await ctx.send("There was a problem setting your port. Please check to ensure you're attempting to use a port from 1024 to 65535") 
+    
+
+    @tgdb_config.command(aliases=['name', 'user'])
+    @checks.is_owner()
+    async def username(self, ctx, user: str):
+        """
+        Sets the user that will be used with the MySQL database. Defaults to SS13
+
+        It's recommended to ensure that this user cannot write to the database 
+        """
+        try:
+            await self.config.guild(ctx.guild).mysql_user.set(user)
+            await ctx.send(f"User set to: `{user}`")
+        except (ValueError, KeyError, AttributeError):
+            await ctx.send("There was a problem setting the username for your database.")
+    
+
+    @tgdb_config.command()
+    @checks.is_owner()
+    async def password(self, ctx, passwd: str):
+        """
+        Sets the password for connecting to the database
+
+        This will be stored locally, it is recommended to ensure that your user cannot write to the database
+        """
+        try:
+            await self.config.guild(ctx.guild).mysql_password.set(passwd)
+            await ctx.send("Your password has been set.")
+            try:
+                await ctx.message.delete()
+            except(discord.DiscordException):
+                await ctx.send("I do not have the required permissions to delete messages, please remove/edit the password manually.")
+        except (ValueError, KeyError, AttributeError):
+            await ctx.send("There was a problem setting the password for your database.")
+
+
+    @tgdb_config.command(aliases=["db"])
+    @checks.is_owner()
+    async def database(self, ctx, db: str):
+        """
+        Sets the database to login to, defaults to feedback
+        """
+        try:
+            await self.config.guild(ctx.guild).mysql_db.set(db)
+            await ctx.send(f"Database set to: `{db}`")
+        except (ValueError, KeyError, AttributeError):
+            await ctx.send ("There was a problem setting your notes database.")
+    
+
+    @tgdb_config.command()
+    @checks.is_owner()
+    async def prefix(self, ctx, prefix: str = None):
+        """
+        Sets the database prefix (if applicable)
+
+        Leave blank to remove this option
+        """
+        try:
+            if prefix is None:
+                await self.config.guild(ctx.guild).mysql_prefix.set("")
+                await ctx.send(f"Database prefix removed!")
+            else:
+                await self.config.guild(ctx.guild).mysql_prefix.set(prefix)
+                await ctx.send(f"Database prefix set to: `{prefix}`")
+        
+        except (ValueError, KeyError, AttributeError):
+            await ctx.send("There was a problem setting your database prefix")
+    
+
+    @checks.mod_or_permissions(administrator=True)
+    @tgdb_config.command()
+    async def current(self, ctx):
+        """
+        Gets the current settings for the notes database
+        """
+        settings = await self.config.guild(ctx.guild).all()
+        embed=discord.Embed(title="__Current settings:__")
+        for k, v in settings.items():
+            # Ensures that the database password is not sent
+            # Whitelist for extra safety
+            if k in self.visible_config:
+                if v == "":
+                    v = None
+                embed.add_field(name=f"{k}:",value=v,inline=False)
+            else:
+                embed.add_field(name=f"{k}:",value="`redacted`",inline=False)
+        await ctx.send(embed=embed)
+
+
+    async def update_discord_link(self, ctx, one_time_token: str, user_discord_snowflake: str):
+        """
+        Given a one time token, and a discord user snowflake, insert the snowflake for the matching record in the discord links table
+        """
+        prefix = await self.config.guild(ctx.guild).mysql_prefix()
+        query = f"UPDATE {prefix}discord_links SET discord_id = %s WHERE one_time_token = %s AND timestamp >= Now() - INTERVAL 4 HOUR AND discord_id IS NULL"
+        parameters = [user_discord_snowflake, one_time_token]
+        query = await self.query_database(ctx, query, parameters)
+
+    async def lookup_ckey_by_token(self, ctx, one_time_token: str):
+        """
+        Given a one time token, search the {prefix}discord_links table for that one time token and return the ckey it's connected to
+        checks that the timestamp of the one time token has not exceeded 4 hours (hence expired) or there is no discord_id associated
+        to that one time key already (it has been used)
+        """
+        prefix = await self.config.guild(ctx.guild).mysql_prefix()
+        query = f"SELECT ckey FROM {prefix}discord_links WHERE one_time_token = %s AND timestamp >= Now() - INTERVAL 4 HOUR AND discord_id IS NULL";
+        parameters = [one_time_token]
+        query = await self.query_database(ctx, query, [one_time_token])
+        try:
+            query = query[0] # Checks to see if a player was found, if the list is empty nothing was found so we return the empty dict.
+        except IndexError:
+            return None
+        return query['ckey']
+
+    async def discord_link_for_discord_id(self, ctx, discord_id):
+        """
+        Given a valid discord id, return the latest record linked to that user
+        """
+        prefix = await self.config.guild(ctx.guild).mysql_prefix()
+        query = f"SELECT * FROM {prefix}discord_links WHERE discord_id = %s AND ckey IS NOT NULL ORDER BY timestamp DESC LIMIT 1";
+        parameters = [discord_id]
+        results = await self.query_database(ctx, query, parameters)
+        if len(results):
+            return DiscordLink(**results[0])
+    
+        return None
+    
+    async def discord_link_for_ckey(self, ctx, ckey):
+        """
+        Given a valid ckey, return the latest record linked to that user
+        """
+        prefix = await self.config.guild(ctx.guild).mysql_prefix()
+        query = f"SELECT * FROM {prefix}discord_links WHERE ckey = %s AND discord_id IS NOT NULL ORDER BY timestamp DESC LIMIT 1";
+        parameters = [ckey]
+        results = await self.query_database(ctx, query, parameters)
+        if len(results):
+            return DiscordLink(**results[0])
+    
+        return None
+
+    async def is_latest_link(self, ctx, first_link):
+        """
+        Given a discord link attribute, check if it is the latest record by *ckey* match
+        """
+        second_link = await self.discord_link_for_ckey(ctx, first_link.ckey)
+        return second_link.id == first_link.id
+    
+    
+    async def get_all_links_to_ckey(self, ctx, ckey):
+        """
+        Given a valid ckey, return a list of all the valid records in the discord_links table for this user as discord link records
+        """
+        prefix = await self.config.guild(ctx.guild).mysql_prefix()
+        query = f"SELECT * FROM {prefix}discord_links WHERE ckey = %s AND discord_id IS NOT NULL";
+        parameters = [ckey]
+        discord_links = list()
+        results = await self.query_database(ctx, query, parameters)
+        for result in results:
+            discord_links.append(DiscordLink(**result))
+        return discord_links
+
+    async def get_player_by_ckey(self, ctx, ckey: str):
+        """
+        Given a ckey, look up the player and return some useful information we use to calculate if we can verify this user or not, (do they have
+        an appropriate amount of living time)
+        """
+        prefix = await self.config.guild(ctx.guild).mysql_prefix()
+        query = f"SELECT ckey, firstseen, lastseen, computerid, ip, accountjoindate FROM {prefix}player WHERE ckey=%s"
+        query = await self.query_database(ctx, query, [ckey])
+        results = {}
+        try:
+            query = query[0] # Checks to see if a player was found, if the list is empty nothing was found so we return the empty dict.
+        except IndexError:
+            return None
+
+        results['ip'] = ipaddress.IPv4Address(query['ip']) #IP's are stored as a 32 bit integer, converting it for readability
+        results['cid'] = query['computerid']
+        results['ckey'] = query['ckey']
+        results['first'] = query['firstseen']
+        results['last'] = query['lastseen']
+        results['join'] = query['accountjoindate']
+
+        #Obtain role time statistics
+        query = f"SELECT job, minutes FROM {prefix}role_time WHERE ckey=%s AND (job='Ghost' OR job='Living')"
+        try:
+            query = await self.query_database(ctx, query, [ckey])
+        except aiomysql.Error:
+            query = None
+        if query:
+            for job in query:
+                if job['job'] == "Living":
+                    results['living_time'] = job['minutes']
+                else:
+                    results['ghost_time'] = job['minutes']
+
+            if 'living_time' not in results.keys():
+                results['living_time'] = 0
+            if 'ghost_time' not in results.keys():
+                results['ghost_time'] = 0
+
+        else:
+            results['living_time'] = 0
+            results['ghost_time'] = 0
+
+            results['total_time'] = results['living_time'] + results['ghost_time']
+        
+        return results
+    
+    async def query_database(self, ctx, query: str, parameters: list):
+        '''
+        Open a connection to the database, and pass in the given query
+        '''
+        # Database options loaded from the config
+        db = await self.config.guild(ctx.guild).mysql_db()
+        db_host = socket.gethostbyname(await self.config.guild(ctx.guild).mysql_host())
+        db_port = await self.config.guild(ctx.guild).mysql_port()
+        db_user = await self.config.guild(ctx.guild).mysql_user()
+        db_pass = await self.config.guild(ctx.guild).mysql_password()
+
+        pool = None # Since the pool variables can't actually be closed if the connection isn't properly established we set a None type here
+
+        try:
+            # Establish a connection with the database and pull the relevant data
+            pool = await aiomysql.create_pool(host=db_host,port=db_port,db=db,user=db_user,password=db_pass, connect_timeout=5)
+            log.debug(f"Executing query {query}, with parameters {parameters}")
+            async with pool.acquire() as conn:
+                async with conn.cursor(aiomysql.DictCursor) as cur:
+                    await cur.execute(query, parameters)
+                    rows = cur.fetchall()
+                    # WRITE TO STORAGE LOL
+                    await conn.commit()
+                    return rows.result()
+            
+        except:
+            raise 
+
+        finally:
+            if pool is not None:
+                pool.close()
+                await pool.wait_closed()

--- a/tgdb/util.py
+++ b/tgdb/util.py
@@ -1,0 +1,4 @@
+import re
+
+def key_to_ckey(key):
+	return re.sub('[^A-Za-z0-9]+', '', key)

--- a/tgdb/util.py
+++ b/tgdb/util.py
@@ -1,4 +1,0 @@
-import re
-
-def key_to_ckey(key):
-	return re.sub('[^A-Za-z0-9]+', '', key)

--- a/tgverify/__init__.py
+++ b/tgverify/__init__.py
@@ -1,0 +1,4 @@
+from .tgverify import TGverify
+
+def setup(bot):
+    bot.add_cog(TGverify(bot))

--- a/tgverify/info.json
+++ b/tgverify/info.json
@@ -1,0 +1,15 @@
+{
+    "author": ["oranges"],
+    "install_msg": "Thank you for installing tgverify.",
+    "name": "SS13 verification module",
+    "short": "The tgverify cog",
+    "description": "This cog uses tgdb cog to allow the automated linking/verification and role application to users",
+    "permissions" : ["Manage Messages", "Manage Roles"],
+    "tags": [
+        "Space Station 13",
+        "Game",
+        "Administration",
+        "Utility",
+        "SS13"
+    ]
+}

--- a/tgverify/tgverify.py
+++ b/tgverify/tgverify.py
@@ -191,7 +191,7 @@ class TGverify(BaseCog):
 
         message = await ctx.send("Attempting to verify you....")
         async with ctx.typing():
-            # First lets try to remove their one time token
+            # First lets try to remove their message
             try:
                 await ctx.message.delete()
             except(discord.DiscordException):
@@ -201,7 +201,7 @@ class TGverify(BaseCog):
                 # Attempt to find the user based on the one time token passed in.
                 ckey = await TGDB.lookup_ckey_by_token(ctx, one_time_token)
                 
-            # they haven't specified a one time token, see if we already have a linked ckey for them, that's valid
+            # they haven't specified a one time token, see if we already have a linked ckey for them, that's valid as a fast path
             else:
                 discord_link = await TGDB.discord_link_for_discord_id(ctx, ctx.author.id)
                 if(discord_link and await TGDB.is_latest_link(ctx, discord_link)):
@@ -209,7 +209,7 @@ class TGverify(BaseCog):
                     await ctx.author.add_roles(role, reason="User has verified against their in game living minutes")
                     return await message.edit(content=f"Congrats {ctx.author} your verification is complete")
 
-                return await message.edit(content=f"You have not previously linked this account with our database, see {instructions_link} for how you carry out this process")
+                return await message.edit(content=f"You have not previously linked this account with our database so must generate a one time token to verify, see {instructions_link} for how you carry out this process")
 
             
             if ckey is None:

--- a/tgverify/tgverify.py
+++ b/tgverify/tgverify.py
@@ -58,13 +58,12 @@ class TGverify(BaseCog):
     @tgverify_config.command()
     async def current(self, ctx):
         """
-        Gets the current settings for the notes database
+        Gets the current settings for the verification system
         """
         settings = await self.config.guild(ctx.guild).all()
         embed=discord.Embed(title="__Current settings:__")
         for k, v in settings.items():
-            # Ensures that the database password is not sent
-            # Whitelist for extra safety
+            # Hide any non whitelisted config settings (safety moment)
             if k in self.visible_config:
                 if v == "":
                     v = None
@@ -123,6 +122,9 @@ class TGverify(BaseCog):
 
     @tgverify.command()
     async def discords(self, ctx, ckey: str):
+        """
+        List all past discord accounts this ckey has verified with
+        """
         tgdb = self.get_tgdb()
         ckey = normalise_to_ckey(ckey)
         message = await ctx.send("Collecting discord accounts for ckey....")
@@ -131,7 +133,7 @@ class TGverify(BaseCog):
             embed.set_author(name=f"Discord accounts historically linked to {str(ckey).title()}")
             links = await tgdb.get_all_links_to_ckey(ctx, ckey)
             if len(links) <= 0:
-                return await message.edit("No discord accounts found for this ckey")
+                return await message.edit(content="No discord accounts found for this ckey")
 
             names = ""
             for link in links:
@@ -143,6 +145,9 @@ class TGverify(BaseCog):
     
     @tgverify.command()
     async def whois(self, ctx, discord_user: discord.User):
+        """
+        Return the ckey attached to the given discord user, if they have one
+        """
         tgdb = self.get_tgdb()
 
         message = await ctx.send("Finding out the ckey of user....")
@@ -154,7 +159,7 @@ class TGverify(BaseCog):
             else:
                 message = await message.edit(content=f"This discord user has no ckey linked")
     
-    #Now the only user facing command
+    #Now the only user facing command, so this has rate limiting across the sky
     @commands.cooldown(2, 60, type=commands.BucketType.user)
     @commands.cooldown(6, 60, type=commands.BucketType.guild)
     @commands.max_concurrency(3, per=commands.BucketType.guild, wait=False)

--- a/tgverify/tgverify.py
+++ b/tgverify/tgverify.py
@@ -1,0 +1,258 @@
+#Standard Imports
+import logging
+from typing import Union
+
+#Discord Imports
+import discord
+
+#Redbot Imports
+from redbot.core import commands, checks, Config
+
+
+__version__ = "1.1.0"
+__author__ = "oranges"
+
+log = logging.getLogger("red.oranges_tgverify")
+
+BaseCog = getattr(commands, "Cog", object)
+
+#Subtype the commands checkfailure
+class TGRecoverableError(commands.CheckFailure):
+    pass
+
+class TGUnrecoverableError(commands.CheckFailure):
+    pass
+
+class TGverify(BaseCog):
+    """
+    Connector that will integrate with any database using the latest tg schema, provides utility functionality
+    """
+    def __init__(self, bot):
+        self.bot = bot
+        self.config = Config.get_conf(self, identifier=672261474290237490, force_registration=True)
+        self.visible_config = ["min_living_minutes", "verified_role"]
+
+        default_guild = {
+            "min_living_minutes": 60,
+            "verified_role": None,
+            "instructions_link": ""
+        }
+
+        self.config.register_guild(**default_guild)
+    
+
+
+    @commands.guild_only()
+    @commands.group()
+    @checks.mod_or_permissions(administrator=True)
+    async def tgverify(self,ctx): 
+        """
+        SS13 Configure the settings on the verification cog
+        """
+        pass
+
+    @commands.guild_only()
+    @commands.group()
+    @checks.mod_or_permissions(administrator=True)
+    async def tgverify_config(self,ctx): 
+        """
+        SS13 Configure the settings on the verification cog
+        """
+        pass
+
+    @tgverify_config.command()
+    async def current(self, ctx):
+        """
+        Gets the current settings for the notes database
+        """
+        settings = await self.config.guild(ctx.guild).all()
+        embed=discord.Embed(title="__Current settings:__")
+        for k, v in settings.items():
+            # Ensures that the database password is not sent
+            # Whitelist for extra safety
+            if k in self.visible_config:
+                if v == "":
+                    v = None
+                embed.add_field(name=f"{k}:",value=v,inline=False)
+            else:
+                embed.add_field(name=f"{k}:",value="`redacted`",inline=False)
+        await ctx.send(embed=embed)
+
+
+    @tgverify_config.command()
+    async def living_minutes(self, ctx, min_living_minutes: int = None):
+        """
+        Sets the minimum required living minutes before this bot will apply a verification role to a user
+        """
+        try:
+            if min_living_minutes is None:
+                await self.config.guild(ctx.guild).min_living_minutes.set(0)
+                await ctx.send(f"Minimum living minutes required for verification removed!")
+            else:
+                await self.config.guild(ctx.guild).min_living_minutes.set(min_living_minutes)
+                await ctx.send(f"Minimum living minutes required for verification set to: `{min_living_minutes}`")
+        
+        except (ValueError, KeyError, AttributeError):
+            await ctx.send("There was a problem setting the minimum required living minutes")
+
+    @tgverify_config.command()
+    async def instructions_link(self, ctx, instruction_link: str):
+        """
+        Sets the link to further instructions on how to generate verification information
+        """
+        try:
+            await self.config.guild(ctx.guild).instructions_link.set(instruction_link)
+            await ctx.send(f"Instruction link set to: `{instruction_link}`")
+        
+        except (ValueError, KeyError, AttributeError):
+            await ctx.send("There was a problem setting the instructions link")
+    
+    @tgverify_config.command()
+    async def verified_role(self, ctx, verified_role: int = None):
+        """
+        Set what role is applied when a user verifies
+        """
+        try:
+            role = ctx.guild.get_role(verified_role)
+            if not role:
+                return await ctx.send(f"This is not a valid role for this discord!")
+            if verified_role is None:
+                await self.config.guild(ctx.guild).verified_role.set(None)
+                await ctx.send(f"No role will be set when the user verifies!")
+            else:
+                await self.config.guild(ctx.guild).verified_role.set(verified_role)
+                await ctx.send(f"When a user meets minimum verification this role will be applied: `{verified_role}`")
+        
+        except (ValueError, KeyError, AttributeError):
+            await ctx.send("There was a problem setting the verified role")    
+
+    @tgverify.command()
+    async def list_discords(self, ctx, ckey: str):
+        TGDB = self.bot.get_cog("TGDB")
+        if not TGDB:
+            raise TGUnrecoverableError("TGDB must exist and be configured for tgverify cog to work")
+
+        message = await ctx.send("Collecting discord accounts for ckey....")
+        async with ctx.typing():
+            embed=discord.Embed(color=await ctx.embed_color())
+            embed.set_author(name=f"Discord accounts historically linked to {str(ckey).title()}")
+            links = await TGDB.get_all_links_to_ckey(ctx, ckey)
+            if len(links) <= 0:
+                return await message.edit("No discord accounts found for this ckey")
+
+            names = ""
+            for link in links:
+                names += f"User has linked <@{link.discord_id}> on {link.timestamp}\n"
+
+            embed.add_field(name="__Discord accounts__", value=names, inline=False)
+            await message.edit(content=None, embed=embed)
+            
+    
+    @tgverify.command()
+    async def whois(self, ctx, discord_user: discord.User):
+        TGDB = self.bot.get_cog("TGDB")
+        if not TGDB:
+            raise TGUnrecoverableError("TGDB must exist and be configured for tgverify cog to work")
+
+        message = await ctx.send("Finding out the ckey of user....")
+        async with ctx.typing():
+            # Attempt to find the discord ids based on the one time token passed in.
+            discord_link = await TGDB.discord_link_for_discord_id(ctx, discord_user.id)
+            if discord_link:
+                message = await message.edit(content=f"This discord user is linked to the ckey {discord_link.ckey}")
+            else:
+                message = await message.edit(content=f"This discord user has no ckey linked")
+    
+    #Now the only user facing command
+    @commands.cooldown(2, 60, type=commands.BucketType.user)
+    @commands.cooldown(6, 60, type=commands.BucketType.guild)
+    @commands.max_concurrency(3, per=commands.BucketType.guild, wait=False)
+    @commands.guild_only()
+    @commands.command()
+    async def verify(self, ctx, *, one_time_token: str = None):
+        """
+        Attempt to verify the user, based on the passed in one time code
+        This command is rated limited to two attempts per user every 60 seconds, and 6 attempts per entire discord every 60 seconds
+        """
+        #Get the minimum required living minutes
+        min_required_living_minutes = await self.config.guild(ctx.guild).min_living_minutes()
+        instructions_link = await self.config.guild(ctx.guild).instructions_link()
+        role = await self.config.guild(ctx.guild).verified_role()
+        role = ctx.guild.get_role(role)
+        TGDB = self.bot.get_cog("TGDB")
+        if not TGDB:
+            raise TGUnrecoverableError("TGDB must exist and be configured for tgverify cog to work")
+
+        if not role:
+            raise TGUnrecoverableError("No verification role is configured, configure it with .tgverify_config role")
+
+        if role in ctx.author.roles:
+            return await ctx.send("You already are verified")
+
+        message = await ctx.send("Attempting to verify you....")
+        async with ctx.typing():
+            # First lets try to remove their one time token
+            try:
+                await ctx.message.delete()
+            except(discord.DiscordException):
+                await ctx.send("I do not have the required permissions to delete messages, please remove/edit the one time token manually.")
+            
+            if one_time_token:
+                # Attempt to find the user based on the one time token passed in.
+                ckey = await TGDB.lookup_ckey_by_token(ctx, one_time_token)
+                
+            # they haven't specified a one time token, see if we already have a linked ckey for them, that's valid
+            else:
+                discord_link = await TGDB.discord_link_for_discord_id(ctx, ctx.author.id)
+                if(discord_link and await TGDB.is_latest_link(ctx, discord_link)):
+                    # we have a fast path, just reapply the linked role and bail
+                    await ctx.author.add_roles(role, reason="User has verified against their in game living minutes")
+                    return await message.edit(content=f"Congrats {ctx.author} your verification is complete")
+
+                return await message.edit(content=f"You have not previously linked this account with our database, see {instructions_link} for how you carry out this process")
+
+            
+            if ckey is None:
+                raise TGRecoverableError(f"Sorry {ctx.author} it looks like we don't recognise this one use token or it has expired, go back into game and try generating one another! See {instructions_link} for more information. \n\nIf it's still failing after a few tries, ask for support from the verification team, ")
+            
+            log.info(f"Verification request by {ctx.author.id}, for ckey {ckey}")
+            # Now look for the user based on the ckey
+            player = await TGDB.get_player_by_ckey(ctx, ckey)
+            
+            if player is None:
+                raise TGRecoverableError(f"Sorry {ctx.author} looks like we couldn't look up your user, ask the verification team for support!")
+
+            if player['living_time'] <= min_required_living_minutes:
+                return await message.edit(content=f"Sorry {ctx.author} you only have {player['living_time']} minutes as a living player on our servers, and you require at least {min_required_living_minutes}! You will need to play more on our servers to access all the discord channels, see {instructions_link} for more information")
+    
+            if role:
+                await ctx.author.add_roles(role, reason="User has verified against their in game living minutes")
+
+
+        # Record that the user is linked against a discord id
+        await TGDB.update_discord_link(ctx, one_time_token, ctx.author.id)
+        return await message.edit(content=f"Congrats {ctx.author} your verification is complete", color=0xff0000)
+
+    @verify.error
+    async def verify_error(self, ctx, error):
+        # Our custom, something recoverable went wrong error type
+        if isinstance(error, TGRecoverableError):
+            embed=discord.Embed(title=f"Error attempting to verify you:", description=f"{format(error)}", color=0xff0000)
+            await ctx.send(content=f"", embed=embed)
+
+        elif isinstance(error, commands.MaxConcurrencyReached):
+            embed=discord.Embed(title=f"There are too many verifications in process, try again in 30 seconds:", description=f"{format(error)}", color=0xff0000)
+            await ctx.send(content=f"", embed=embed)
+            log.exception(f"Too many users attempting to verify concurrently, db wait hit?")
+
+        elif isinstance(error, commands.CommandOnCooldown):
+            embed=discord.Embed(title=f"Hey slow down buddy:", description=f"{format(error)}", color=0xff0000)
+            await ctx.send(content=f"", embed=embed)
+            log.warning(f"Verification limit hit, user is being bad {ctx.author}, discord id {ctx.author.id}")
+
+        else:
+            # Something went badly wrong, log to the console
+            log.exception("Internal error while verifying a user")
+            # now pretend everything is fine to the user :>
+            embed=discord.Embed(title=f"System error occurred", description=f"Contact the server admins for assistance", color=0xff0000)
+            await ctx.send(content=f"", embed=embed)


### PR DESCRIPTION
This is the bot side of the tg verification system, the DM side was added in PR:
https://github.com/tgstation/tgstation/pull/52764

The user takes their one time token and puts it into the verification
channel. The discord bot cog then compares this token to the database to
find the matching discord link

Once matching discord link is found (first discord link entry with the
one time token in the 4 hour time window) then the follow actions are
carried out.

Any discord link entries with the same ckey or a matching discord_id, that
are valid all have their valid field set to FALSE (0), they are no longer good to
verify in discord with, (this should only be the most recent)

Then the found matching discord link has the discord id of the calling
user inserted and the valid field is set to TRUE (1)

TODO:
- [ ] get a working pip install line for tgcommon pulling it from the github
- [ ] minor cleanup of the API
- [ ] pool needs to be fetched from a map of [guild] -> pool otherwise it only works on one server
- [ ] wrap db in sqlalchemy model layer
- [ ] create tgcommon API's for individual uses (i.e DiscordAPI that has all discord link related functions hanging off it)
- [ ] implement <X>API.get_with_context(ctx) that fills out self.db and self.ctx so you don't have to provide it. (should fetch a conn from the appropriate pool for the given guild)
