### PR TITLE
Bans code blocks from being added to the fridge

### DIFF
--- a/fridge/fridge.py
+++ b/fridge/fridge.py
@@ -134,7 +134,7 @@ class Fridge(BaseCog):
             await ctx.send(f"This is too big to fit in the fridge")
             return
 
-        if item.count("\n") > 5:
+        if item.count("\n") > 5 or "```" in item:
             await ctx.send(f"This is too spammy to fit in the fridge")
             return
 


### PR DESCRIPTION
Adds an extra check for ``` to the fridge's add() to stop people from spamming with fridge items containing blocks of code.